### PR TITLE
Composer doesn't install to the plugins folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     ]
   },
   "require": {
-    "gumlet/php-image-resize": "1.9.*"
+    "gumlet/php-image-resize": "1.9.*",
+    "getkirby/composer-installer": "^1.1"
   }
 }


### PR DESCRIPTION
Currently composer installs in the vendor folder instead of site/plugins. According to the docs you need getkirby/composer-installer to take care of this. See https://getkirby.com/docs/guide/plugins/plugin-setup-basic.

Haven't tried this myself though so please review if it actually works :-)